### PR TITLE
[feat] adding vcs support to systemc cosim demo

### DIFF
--- a/Makefile.vcs
+++ b/Makefile.vcs
@@ -1,5 +1,5 @@
 # flags for synopsys tools
-SNPS_FLAGS = -full64 -cpp g++-6 -cc gcc-6
+SNPS_FLAGS = -full64 -cpp g++-6 -cc gcc-6 -kdb -lca
 CC = gcc-6
 CXX = g++-6
 SNPS_CFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc232 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
@@ -42,15 +42,15 @@ COSIM_SYSC_FILES = debugdev.cc \
 CXX_FILES = $(RP_CXX_FILES) $(COSIM_SYSC_FILES)
 C_FILES = $(RP_C_FILES)
 
-comp: uvm comp_verilog comp_c libsc_hier.so
+comp: uvm sysc_verilog comp_c libsc_hier.so comp_verilog
 	mkdir work -p
 	echo "compiling c++ files"
-	vcs -sysc $(SNPS_FLAGS) -ntb_opts uvm -debug_access+all libsc_hier.so sc_main -timescale=1ps/1fs -lca -o simv2
+	vcs -j16 -sysc $(SNPS_FLAGS) libsc_hier.so -sysc=show_sc_main sc_main test_bench -ntb_opts uvm -debug_access+all  -timescale=1ps/1fs -o simv2
 
 
-comp_verilog: axi_ram.v
-	vlogan $(SNPS_FLAGS) -sysc -sysc=opt_if -sysc=gen_portmap axi_ram.v -sc_model axi_ram
-	vlogan $(SNPS_FLAGS) -sysc axi_ram.v -sc_model axi_ram -sc_portmap axi_ram.portmap
+sysc_verilog: sysc_verilog_top.sv
+	vlogan $(SNPS_FLAGS) $(SNPS_VFLAGS) -sverilog -sysc -sysc=opt_if -sysc=gen_portmap sysc_verilog_top.sv -sc_model sysc_verilog_top
+	vlogan $(SNPS_FLAGS) $(SNPS_VFLAGS) -sverilog -sysc -sysc=opt_if sysc_verilog_top.sv -sc_model sysc_verilog_top -sc_portmap sysc_verilog_top.portmap
 
 # TODO: finer grain control
 comp_c: $(CXX_FILES) $(C_FILES)
@@ -58,8 +58,11 @@ comp_c: $(CXX_FILES) $(C_FILES)
 	$(CC) -c $(SNPS_CFLAGS) $(C_FILES)
 	$(CC) -g -fPIC -shared -o libsc_hier.so *.o
 
+comp_verilog:
+	vlogan $(SNPS_FLAGS) $(SNPS_VFLAGS) -f Flist
+
 uvm:
-	vlogan $(SNPS_FLAGS) -sverilog -ntb_opts uvm
+	vlogan $(SNPS_FLAGS) $(SNPS_VFLAGS) -sverilog -ntb_opts uvm
 
 
 

--- a/Makefile.vcs
+++ b/Makefile.vcs
@@ -1,0 +1,67 @@
+# flags for synopsys tools
+SNPS_FLAGS = -full64 -cpp g++-6 -cc gcc-6
+CC = gcc-6
+CXX = g++-6
+SNPS_CFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc231 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
+SNPS_CXXFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc231 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
+
+# path for libremote port
+LIBSOC_PATH=libsystemctlm-soc
+LIBSOC_ZYNQMP_PATH=$(LIBSOC_PATH)/soc/xilinx/zynqmp
+LIBRP_PATH=$(LIBSOC_PATH)/libremote-port
+
+# include files for lib remote port
+SNPS_CXXFLAGS += -I $(LIBRP_PATH) -I $(LIBSOC_PATH)
+SNPS_CFLAGS += -I $(LIBRP_PATH) -I $(LIBSOC_PATH)
+
+
+#include header files in this directory
+SNPS_CXXFLAGS += -I . -I $(LIBSOC_ZYNQMP_PATH) -I $(LIBSOC_PATH)
+SNPS_CFLAGS += -I . -I $(LIBSOC_ZYNQMP_PATH) -I $(LIBSOC_PATH)
+
+
+
+RP_C_FILES = $(LIBRP_PATH)/safeio.c \
+	     $(LIBRP_PATH)/remote-port-proto.c \
+	     $(LIBRP_PATH)/remote-port-sk.c
+
+RP_CXX_FILES = $(LIBRP_PATH)/remote-port-tlm.cc \
+	       $(LIBRP_PATH)/remote-port-tlm-memory-master.cc \
+	       $(LIBRP_PATH)/remote-port-tlm-ats.cc \
+	       $(LIBRP_PATH)/remote-port-tlm-pci-ep.cc \
+	       $(LIBRP_PATH)/remote-port-tlm-memory-slave.cc \
+	       $(LIBRP_PATH)/remote-port-tlm-wires.cc
+
+COSIM_SYSC_FILES = debugdev.cc \
+		   demo-dma.cc \
+		   memory.cc \
+		   trace.cc \
+		   zynqmp_demo.cc \
+		   $(LIBSOC_ZYNQMP_PATH)/xilinx-zynqmp.cc
+
+CXX_FILES = $(RP_CXX_FILES) $(COSIM_SYSC_FILES)
+C_FILES = $(RP_C_FILES)
+
+comp: uvm comp_verilog comp_c libsc_hier.so
+	mkdir work -p
+	echo "compiling c++ files"
+	vcs -sysc $(SNPS_FLAGS) -ntb_opts uvm -debug_access+all libsc_hier.so sc_main -timescale=1ps/1fs -lca -o simv2
+
+
+comp_verilog: axi_ram.v
+	vlogan $(SNPS_FLAGS) -sysc -sysc=opt_if -sysc=gen_portmap axi_ram.v -sc_model axi_ram
+	vlogan $(SNPS_FLAGS) -sysc axi_ram.v -sc_model axi_ram -sc_portmap axi_ram.portmap
+
+# TODO: finer grain control
+comp_c: $(CXX_FILES) $(C_FILES)
+	syscan $(SNPS_FLAGS) -cflags "$(SNPS_CXXFLAGS)" $(CXX_FILES)
+	$(CC) -c $(SNPS_CFLAGS) $(C_FILES)
+	$(CC) -g -fPIC -shared -o libsc_hier.so *.o
+
+uvm:
+	vlogan $(SNPS_FLAGS) -sverilog -ntb_opts uvm
+
+
+
+clean:
+	rm -rf AN.DB csrc simv2.daidir simv2 work ucli.key vc_hdrs.h DVEfiles *.vpd dir1 *.o *.d *.so  tli_uvm_mem_data.sv *.log *.portmap *.error 64 verdiLog novas.conf

--- a/Makefile.vcs
+++ b/Makefile.vcs
@@ -36,7 +36,7 @@ COSIM_SYSC_FILES = debugdev.cc \
 		   demo-dma.cc \
 		   memory.cc \
 		   trace.cc \
-		   zynqmp_demo.cc \
+		   zynqmp_vcs_demo.cc \
 		   $(LIBSOC_ZYNQMP_PATH)/xilinx-zynqmp.cc
 
 CXX_FILES = $(RP_CXX_FILES) $(COSIM_SYSC_FILES)

--- a/Makefile.vcs
+++ b/Makefile.vcs
@@ -2,8 +2,8 @@
 SNPS_FLAGS = -full64 -cpp g++-6 -cc gcc-6
 CC = gcc-6
 CXX = g++-6
-SNPS_CFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc231 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
-SNPS_CXXFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc231 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
+SNPS_CFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc232 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
+SNPS_CXXFLAGS = -I${PWD}/csrc/sysc/include -I${VCS_HOME}/etc/systemc/tlm/tli -DTLI_BYTE_VIEW_DEBUG  -DVCS  -I${VCS_HOME}/include/systemc232 -I${VCS_HOME}/etc/systemc/tlm/include/tlm -I${VCS_HOME}/include -I${VCS_HOME}/include/cosim/bf -fPIC -g -Og -m64
 
 # path for libremote port
 LIBSOC_PATH=libsystemctlm-soc

--- a/axi_ram.v
+++ b/axi_ram.v
@@ -1,0 +1,363 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ps / 1fs
+
+`define DATA_WIDTH 32
+`define ADDR_WIDTH 8
+`define STRB_WIDTH 4
+`define ID_WIDTH 8
+`define PIPELINE_OUTPUT 0
+/*
+ * AXI4 RAM
+ */
+module axi_ram
+(
+    input  wire                   clk,
+    input  wire                   rst,
+
+    input  wire [`ID_WIDTH-1:0]    s_axi_awid,
+    input  wire [`ADDR_WIDTH-1:0]  s_axi_awaddr,
+    input  wire [7:0]             s_axi_awlen,
+    input  wire [2:0]             s_axi_awsize,
+    input  wire [1:0]             s_axi_awburst,
+    input  wire                   s_axi_awlock,
+    input  wire [3:0]             s_axi_awcache,
+    input  wire [2:0]             s_axi_awprot,
+    input  wire                   s_axi_awvalid,
+    output wire                   s_axi_awready,
+    input  wire [`DATA_WIDTH-1:0]  s_axi_wdata,
+    input  wire [`STRB_WIDTH-1:0]  s_axi_wstrb,
+    input  wire                   s_axi_wlast,
+    input  wire                   s_axi_wvalid,
+    output wire                   s_axi_wready,
+    output wire [`ID_WIDTH-1:0]    s_axi_bid,
+    output wire [1:0]             s_axi_bresp,
+    output wire                   s_axi_bvalid,
+    input  wire                   s_axi_bready,
+    input  wire [`ID_WIDTH-1:0]    s_axi_arid,
+    input  wire [`ADDR_WIDTH-1:0]  s_axi_araddr,
+    input  wire [7:0]             s_axi_arlen,
+    input  wire [2:0]             s_axi_arsize,
+    input  wire [1:0]             s_axi_arburst,
+    input  wire                   s_axi_arlock,
+    input  wire [3:0]             s_axi_arcache,
+    input  wire [2:0]             s_axi_arprot,
+    input  wire                   s_axi_arvalid,
+    output wire                   s_axi_arready,
+    output wire [`ID_WIDTH-1:0]    s_axi_rid,
+    output wire [`DATA_WIDTH-1:0]  s_axi_rdata,
+    output wire [1:0]             s_axi_rresp,
+    output wire                   s_axi_rlast,
+    output wire                   s_axi_rvalid,
+    input  wire                   s_axi_rready
+);
+
+parameter VALID_ADDR_WIDTH = `ADDR_WIDTH - $clog2(`STRB_WIDTH);
+parameter WORD_WIDTH = `STRB_WIDTH;
+parameter WORD_SIZE = `DATA_WIDTH/WORD_WIDTH;
+
+// bus width assertions
+initial begin
+    if (WORD_SIZE * `STRB_WIDTH != `DATA_WIDTH) begin
+        $error("Error: AXI data width not evenly divisble (instance %m)");
+        $finish;
+    end
+
+    if (2**$clog2(WORD_WIDTH) != WORD_WIDTH) begin
+        $error("Error: AXI word width must be even power of two (instance %m)");
+        $finish;
+    end
+end
+
+localparam [0:0]
+    READ_STATE_IDLE = 1'd0,
+    READ_STATE_BURST = 1'd1;
+
+reg [0:0] read_state_reg = READ_STATE_IDLE, read_state_next;
+
+localparam [1:0]
+    WRITE_STATE_IDLE = 2'd0,
+    WRITE_STATE_BURST = 2'd1,
+    WRITE_STATE_RESP = 2'd2;
+
+reg [1:0] write_state_reg = WRITE_STATE_IDLE, write_state_next;
+
+reg mem_wr_en;
+reg mem_rd_en;
+
+reg [`ID_WIDTH-1:0] read_id_reg = {`ID_WIDTH{1'b0}}, read_id_next;
+reg [`ADDR_WIDTH-1:0] read_addr_reg = {`ADDR_WIDTH{1'b0}}, read_addr_next;
+reg [7:0] read_count_reg = 8'd0, read_count_next;
+reg [2:0] read_size_reg = 3'd0, read_size_next;
+reg [1:0] read_burst_reg = 2'd0, read_burst_next;
+reg [`ID_WIDTH-1:0] write_id_reg = {`ID_WIDTH{1'b0}}, write_id_next;
+reg [`ADDR_WIDTH-1:0] write_addr_reg = {`ADDR_WIDTH{1'b0}}, write_addr_next;
+reg [7:0] write_count_reg = 8'd0, write_count_next;
+reg [2:0] write_size_reg = 3'd0, write_size_next;
+reg [1:0] write_burst_reg = 2'd0, write_burst_next;
+
+reg s_axi_awready_reg = 1'b0, s_axi_awready_next;
+reg s_axi_wready_reg = 1'b0, s_axi_wready_next;
+reg [`ID_WIDTH-1:0] s_axi_bid_reg = {`ID_WIDTH{1'b0}}, s_axi_bid_next;
+reg s_axi_bvalid_reg = 1'b0, s_axi_bvalid_next;
+reg s_axi_arready_reg = 1'b0, s_axi_arready_next;
+reg [`ID_WIDTH-1:0] s_axi_rid_reg = {`ID_WIDTH{1'b0}}, s_axi_rid_next;
+reg [`DATA_WIDTH-1:0] s_axi_rdata_reg = {`DATA_WIDTH{1'b0}}, s_axi_rdata_next;
+reg s_axi_rlast_reg = 1'b0, s_axi_rlast_next;
+reg s_axi_rvalid_reg = 1'b0, s_axi_rvalid_next;
+reg [`ID_WIDTH-1:0] s_axi_rid_pipe_reg = {`ID_WIDTH{1'b0}};
+reg [`DATA_WIDTH-1:0] s_axi_rdata_pipe_reg = {`DATA_WIDTH{1'b0}};
+reg s_axi_rlast_pipe_reg = 1'b0;
+reg s_axi_rvalid_pipe_reg = 1'b0;
+
+// (* RAM_STYLE="BLOCK" *)
+reg [`DATA_WIDTH-1:0] mem[(2**VALID_ADDR_WIDTH)-1:0];
+
+wire [VALID_ADDR_WIDTH-1:0] s_axi_awaddr_valid = s_axi_awaddr >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] s_axi_araddr_valid = s_axi_araddr >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] read_addr_valid = read_addr_reg >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] write_addr_valid = write_addr_reg >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+
+assign s_axi_awready = s_axi_awready_reg;
+assign s_axi_wready = s_axi_wready_reg;
+assign s_axi_bid = s_axi_bid_reg;
+assign s_axi_bresp = 2'b00;
+assign s_axi_bvalid = s_axi_bvalid_reg;
+assign s_axi_arready = s_axi_arready_reg;
+assign s_axi_rid = `PIPELINE_OUTPUT ? s_axi_rid_pipe_reg : s_axi_rid_reg;
+assign s_axi_rdata = `PIPELINE_OUTPUT ? s_axi_rdata_pipe_reg : s_axi_rdata_reg;
+assign s_axi_rresp = 2'b00;
+assign s_axi_rlast = `PIPELINE_OUTPUT ? s_axi_rlast_pipe_reg : s_axi_rlast_reg;
+assign s_axi_rvalid = `PIPELINE_OUTPUT ? s_axi_rvalid_pipe_reg : s_axi_rvalid_reg;
+
+integer i, j;
+
+initial begin
+    // two nested loops for smaller number of iterations per loop
+    // workaround for synthesizer complaints about large loop counts
+    for (i = 0; i < 2**VALID_ADDR_WIDTH; i = i + 2**(VALID_ADDR_WIDTH/2)) begin
+        for (j = i; j < i + 2**(VALID_ADDR_WIDTH/2); j = j + 1) begin
+            mem[j] = i;
+        end
+    end
+end
+
+always @* begin
+    write_state_next = WRITE_STATE_IDLE;
+
+    mem_wr_en = 1'b0;
+
+    write_id_next = write_id_reg;
+    write_addr_next = write_addr_reg;
+    write_count_next = write_count_reg;
+    write_size_next = write_size_reg;
+    write_burst_next = write_burst_reg;
+
+    s_axi_awready_next = 1'b0;
+    s_axi_wready_next = 1'b0;
+    s_axi_bid_next = s_axi_bid_reg;
+    s_axi_bvalid_next = s_axi_bvalid_reg && !s_axi_bready;
+
+    case (write_state_reg)
+        WRITE_STATE_IDLE: begin
+            s_axi_awready_next = 1'b1;
+
+            if (s_axi_awready && s_axi_awvalid) begin
+                write_id_next = s_axi_awid;
+                write_addr_next = s_axi_awaddr;
+                write_count_next = s_axi_awlen;
+                write_size_next = s_axi_awsize < $clog2(`STRB_WIDTH) ? s_axi_awsize : $clog2(`STRB_WIDTH);
+                write_burst_next = s_axi_awburst;
+
+                s_axi_awready_next = 1'b0;
+                s_axi_wready_next = 1'b1;
+                write_state_next = WRITE_STATE_BURST;
+            end else begin
+                write_state_next = WRITE_STATE_IDLE;
+            end
+        end
+        WRITE_STATE_BURST: begin
+            s_axi_wready_next = 1'b1;
+
+            if (s_axi_wready && s_axi_wvalid) begin
+                mem_wr_en = 1'b1;
+                if (write_burst_reg != 2'b00) begin
+                    write_addr_next = write_addr_reg + (1 << write_size_reg);
+                end
+                write_count_next = write_count_reg - 1;
+                if (write_count_reg > 0) begin
+                    write_state_next = WRITE_STATE_BURST;
+                end else begin
+                    s_axi_wready_next = 1'b0;
+                    if (s_axi_bready || !s_axi_bvalid) begin
+                        s_axi_bid_next = write_id_reg;
+                        s_axi_bvalid_next = 1'b1;
+                        s_axi_awready_next = 1'b1;
+                        write_state_next = WRITE_STATE_IDLE;
+                    end else begin
+                        write_state_next = WRITE_STATE_RESP;
+                    end
+                end
+            end else begin
+                write_state_next = WRITE_STATE_BURST;
+            end
+        end
+        WRITE_STATE_RESP: begin
+            if (s_axi_bready || !s_axi_bvalid) begin
+                s_axi_bid_next = write_id_reg;
+                s_axi_bvalid_next = 1'b1;
+                s_axi_awready_next = 1'b1;
+                write_state_next = WRITE_STATE_IDLE;
+            end else begin
+                write_state_next = WRITE_STATE_RESP;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    write_state_reg <= write_state_next;
+
+    write_id_reg <= write_id_next;
+    write_addr_reg <= write_addr_next;
+    write_count_reg <= write_count_next;
+    write_size_reg <= write_size_next;
+    write_burst_reg <= write_burst_next;
+
+    s_axi_awready_reg <= s_axi_awready_next;
+    s_axi_wready_reg <= s_axi_wready_next;
+    s_axi_bid_reg <= s_axi_bid_next;
+    s_axi_bvalid_reg <= s_axi_bvalid_next;
+
+    for (i = 0; i < WORD_WIDTH; i = i + 1) begin
+        if (mem_wr_en & s_axi_wstrb[i]) begin
+            mem[write_addr_valid][WORD_SIZE*i +: WORD_SIZE] <= s_axi_wdata[WORD_SIZE*i +: WORD_SIZE];
+        end
+    end
+
+    if (rst) begin
+        write_state_reg <= WRITE_STATE_IDLE;
+
+        s_axi_awready_reg <= 1'b0;
+        s_axi_wready_reg <= 1'b0;
+        s_axi_bvalid_reg <= 1'b0;
+    end
+end
+
+always @* begin
+    read_state_next = READ_STATE_IDLE;
+
+    mem_rd_en = 1'b0;
+
+    s_axi_rid_next = s_axi_rid_reg;
+    s_axi_rlast_next = s_axi_rlast_reg;
+    s_axi_rvalid_next = s_axi_rvalid_reg && !(s_axi_rready || (`PIPELINE_OUTPUT && !s_axi_rvalid_pipe_reg));
+
+    read_id_next = read_id_reg;
+    read_addr_next = read_addr_reg;
+    read_count_next = read_count_reg;
+    read_size_next = read_size_reg;
+    read_burst_next = read_burst_reg;
+
+    s_axi_arready_next = 1'b0;
+
+    case (read_state_reg)
+        READ_STATE_IDLE: begin
+            s_axi_arready_next = 1'b1;
+
+            if (s_axi_arready && s_axi_arvalid) begin
+                read_id_next = s_axi_arid;
+                read_addr_next = s_axi_araddr;
+                read_count_next = s_axi_arlen;
+                read_size_next = s_axi_arsize < $clog2(`STRB_WIDTH) ? s_axi_arsize : $clog2(`STRB_WIDTH);
+                read_burst_next = s_axi_arburst;
+
+                s_axi_arready_next = 1'b0;
+                read_state_next = READ_STATE_BURST;
+            end else begin
+                read_state_next = READ_STATE_IDLE;
+            end
+        end
+        READ_STATE_BURST: begin
+            if (s_axi_rready || (`PIPELINE_OUTPUT && !s_axi_rvalid_pipe_reg) || !s_axi_rvalid_reg) begin
+                mem_rd_en = 1'b1;
+                s_axi_rvalid_next = 1'b1;
+                s_axi_rid_next = read_id_reg;
+                s_axi_rlast_next = read_count_reg == 0;
+                if (read_burst_reg != 2'b00) begin
+                    read_addr_next = read_addr_reg + (1 << read_size_reg);
+                end
+                read_count_next = read_count_reg - 1;
+                if (read_count_reg > 0) begin
+                    read_state_next = READ_STATE_BURST;
+                end else begin
+                    s_axi_arready_next = 1'b1;
+                    read_state_next = READ_STATE_IDLE;
+                end
+            end else begin
+                read_state_next = READ_STATE_BURST;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    read_state_reg <= read_state_next;
+
+    read_id_reg <= read_id_next;
+    read_addr_reg <= read_addr_next;
+    read_count_reg <= read_count_next;
+    read_size_reg <= read_size_next;
+    read_burst_reg <= read_burst_next;
+
+    s_axi_arready_reg <= s_axi_arready_next;
+    s_axi_rid_reg <= s_axi_rid_next;
+    s_axi_rlast_reg <= s_axi_rlast_next;
+    s_axi_rvalid_reg <= s_axi_rvalid_next;
+
+    if (mem_rd_en) begin
+        s_axi_rdata_reg <= mem[read_addr_valid];
+        $display("Here is a read command\n");
+    end
+
+    if (!s_axi_rvalid_pipe_reg || s_axi_rready) begin
+        s_axi_rid_pipe_reg <= s_axi_rid_reg;
+        s_axi_rdata_pipe_reg <= s_axi_rdata_reg;
+        s_axi_rlast_pipe_reg <= s_axi_rlast_reg;
+        s_axi_rvalid_pipe_reg <= s_axi_rvalid_reg;
+    end
+
+    if (rst) begin
+        read_state_reg <= READ_STATE_IDLE;
+
+        s_axi_arready_reg <= 1'b0;
+        s_axi_rvalid_reg <= 1'b0;
+        s_axi_rvalid_pipe_reg <= 1'b0;
+    end
+end
+
+endmodule

--- a/axi_ram_impl.sv
+++ b/axi_ram_impl.sv
@@ -1,0 +1,363 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ps / 1fs
+
+`define DATA_WIDTH 32
+`define ADDR_WIDTH 8
+`define STRB_WIDTH 4
+`define ID_WIDTH 8
+`define PIPELINE_OUTPUT 0
+/*
+ * AXI4 RAM
+ */
+module axi_ram_impl
+(
+    input  wire                   clk,
+    input  wire                   rst,
+
+    input  wire [`ID_WIDTH-1:0]    s_axi_awid,
+    input  wire [`ADDR_WIDTH-1:0]  s_axi_awaddr,
+    input  wire [7:0]             s_axi_awlen,
+    input  wire [2:0]             s_axi_awsize,
+    input  wire [1:0]             s_axi_awburst,
+    input  wire                   s_axi_awlock,
+    input  wire [3:0]             s_axi_awcache,
+    input  wire [2:0]             s_axi_awprot,
+    input  wire                   s_axi_awvalid,
+    output wire                   s_axi_awready,
+    input  wire [`DATA_WIDTH-1:0]  s_axi_wdata,
+    input  wire [`STRB_WIDTH-1:0]  s_axi_wstrb,
+    input  wire                   s_axi_wlast,
+    input  wire                   s_axi_wvalid,
+    output wire                   s_axi_wready,
+    output wire [`ID_WIDTH-1:0]    s_axi_bid,
+    output wire [1:0]             s_axi_bresp,
+    output wire                   s_axi_bvalid,
+    input  wire                   s_axi_bready,
+    input  wire [`ID_WIDTH-1:0]    s_axi_arid,
+    input  wire [`ADDR_WIDTH-1:0]  s_axi_araddr,
+    input  wire [7:0]             s_axi_arlen,
+    input  wire [2:0]             s_axi_arsize,
+    input  wire [1:0]             s_axi_arburst,
+    input  wire                   s_axi_arlock,
+    input  wire [3:0]             s_axi_arcache,
+    input  wire [2:0]             s_axi_arprot,
+    input  wire                   s_axi_arvalid,
+    output wire                   s_axi_arready,
+    output wire [`ID_WIDTH-1:0]    s_axi_rid,
+    output wire [`DATA_WIDTH-1:0]  s_axi_rdata,
+    output wire [1:0]             s_axi_rresp,
+    output wire                   s_axi_rlast,
+    output wire                   s_axi_rvalid,
+    input  wire                   s_axi_rready
+);
+
+parameter VALID_ADDR_WIDTH = `ADDR_WIDTH - $clog2(`STRB_WIDTH);
+parameter WORD_WIDTH = `STRB_WIDTH;
+parameter WORD_SIZE = `DATA_WIDTH/WORD_WIDTH;
+
+// bus width assertions
+initial begin
+    if (WORD_SIZE * `STRB_WIDTH != `DATA_WIDTH) begin
+        $error("Error: AXI data width not evenly divisble (instance %m)");
+        $finish;
+    end
+
+    if (2**$clog2(WORD_WIDTH) != WORD_WIDTH) begin
+        $error("Error: AXI word width must be even power of two (instance %m)");
+        $finish;
+    end
+end
+
+localparam [0:0]
+    READ_STATE_IDLE = 1'd0,
+    READ_STATE_BURST = 1'd1;
+
+reg [0:0] read_state_reg = READ_STATE_IDLE, read_state_next;
+
+localparam [1:0]
+    WRITE_STATE_IDLE = 2'd0,
+    WRITE_STATE_BURST = 2'd1,
+    WRITE_STATE_RESP = 2'd2;
+
+reg [1:0] write_state_reg = WRITE_STATE_IDLE, write_state_next;
+
+reg mem_wr_en;
+reg mem_rd_en;
+
+reg [`ID_WIDTH-1:0] read_id_reg = {`ID_WIDTH{1'b0}}, read_id_next;
+reg [`ADDR_WIDTH-1:0] read_addr_reg = {`ADDR_WIDTH{1'b0}}, read_addr_next;
+reg [7:0] read_count_reg = 8'd0, read_count_next;
+reg [2:0] read_size_reg = 3'd0, read_size_next;
+reg [1:0] read_burst_reg = 2'd0, read_burst_next;
+reg [`ID_WIDTH-1:0] write_id_reg = {`ID_WIDTH{1'b0}}, write_id_next;
+reg [`ADDR_WIDTH-1:0] write_addr_reg = {`ADDR_WIDTH{1'b0}}, write_addr_next;
+reg [7:0] write_count_reg = 8'd0, write_count_next;
+reg [2:0] write_size_reg = 3'd0, write_size_next;
+reg [1:0] write_burst_reg = 2'd0, write_burst_next;
+
+reg s_axi_awready_reg = 1'b0, s_axi_awready_next;
+reg s_axi_wready_reg = 1'b0, s_axi_wready_next;
+reg [`ID_WIDTH-1:0] s_axi_bid_reg = {`ID_WIDTH{1'b0}}, s_axi_bid_next;
+reg s_axi_bvalid_reg = 1'b0, s_axi_bvalid_next;
+reg s_axi_arready_reg = 1'b0, s_axi_arready_next;
+reg [`ID_WIDTH-1:0] s_axi_rid_reg = {`ID_WIDTH{1'b0}}, s_axi_rid_next;
+reg [`DATA_WIDTH-1:0] s_axi_rdata_reg = {`DATA_WIDTH{1'b0}}, s_axi_rdata_next;
+reg s_axi_rlast_reg = 1'b0, s_axi_rlast_next;
+reg s_axi_rvalid_reg = 1'b0, s_axi_rvalid_next;
+reg [`ID_WIDTH-1:0] s_axi_rid_pipe_reg = {`ID_WIDTH{1'b0}};
+reg [`DATA_WIDTH-1:0] s_axi_rdata_pipe_reg = {`DATA_WIDTH{1'b0}};
+reg s_axi_rlast_pipe_reg = 1'b0;
+reg s_axi_rvalid_pipe_reg = 1'b0;
+
+// (* RAM_STYLE="BLOCK" *)
+reg [`DATA_WIDTH-1:0] mem[(2**VALID_ADDR_WIDTH)-1:0];
+
+wire [VALID_ADDR_WIDTH-1:0] s_axi_awaddr_valid = s_axi_awaddr >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] s_axi_araddr_valid = s_axi_araddr >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] read_addr_valid = read_addr_reg >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] write_addr_valid = write_addr_reg >> (`ADDR_WIDTH - VALID_ADDR_WIDTH);
+
+assign s_axi_awready = s_axi_awready_reg;
+assign s_axi_wready = s_axi_wready_reg;
+assign s_axi_bid = s_axi_bid_reg;
+assign s_axi_bresp = 2'b00;
+assign s_axi_bvalid = s_axi_bvalid_reg;
+assign s_axi_arready = s_axi_arready_reg;
+assign s_axi_rid = `PIPELINE_OUTPUT ? s_axi_rid_pipe_reg : s_axi_rid_reg;
+assign s_axi_rdata = `PIPELINE_OUTPUT ? s_axi_rdata_pipe_reg : s_axi_rdata_reg;
+assign s_axi_rresp = 2'b00;
+assign s_axi_rlast = `PIPELINE_OUTPUT ? s_axi_rlast_pipe_reg : s_axi_rlast_reg;
+assign s_axi_rvalid = `PIPELINE_OUTPUT ? s_axi_rvalid_pipe_reg : s_axi_rvalid_reg;
+
+integer i, j;
+
+initial begin
+    // two nested loops for smaller number of iterations per loop
+    // workaround for synthesizer complaints about large loop counts
+    for (i = 0; i < 2**VALID_ADDR_WIDTH; i = i + 2**(VALID_ADDR_WIDTH/2)) begin
+        for (j = i; j < i + 2**(VALID_ADDR_WIDTH/2); j = j + 1) begin
+            mem[j] = i;
+        end
+    end
+end
+
+always @* begin
+    write_state_next = WRITE_STATE_IDLE;
+
+    mem_wr_en = 1'b0;
+
+    write_id_next = write_id_reg;
+    write_addr_next = write_addr_reg;
+    write_count_next = write_count_reg;
+    write_size_next = write_size_reg;
+    write_burst_next = write_burst_reg;
+
+    s_axi_awready_next = 1'b0;
+    s_axi_wready_next = 1'b0;
+    s_axi_bid_next = s_axi_bid_reg;
+    s_axi_bvalid_next = s_axi_bvalid_reg && !s_axi_bready;
+
+    case (write_state_reg)
+        WRITE_STATE_IDLE: begin
+            s_axi_awready_next = 1'b1;
+
+            if (s_axi_awready && s_axi_awvalid) begin
+                write_id_next = s_axi_awid;
+                write_addr_next = s_axi_awaddr;
+                write_count_next = s_axi_awlen;
+                write_size_next = s_axi_awsize < $clog2(`STRB_WIDTH) ? s_axi_awsize : $clog2(`STRB_WIDTH);
+                write_burst_next = s_axi_awburst;
+
+                s_axi_awready_next = 1'b0;
+                s_axi_wready_next = 1'b1;
+                write_state_next = WRITE_STATE_BURST;
+            end else begin
+                write_state_next = WRITE_STATE_IDLE;
+            end
+        end
+        WRITE_STATE_BURST: begin
+            s_axi_wready_next = 1'b1;
+
+            if (s_axi_wready && s_axi_wvalid) begin
+                mem_wr_en = 1'b1;
+                if (write_burst_reg != 2'b00) begin
+                    write_addr_next = write_addr_reg + (1 << write_size_reg);
+                end
+                write_count_next = write_count_reg - 1;
+                if (write_count_reg > 0) begin
+                    write_state_next = WRITE_STATE_BURST;
+                end else begin
+                    s_axi_wready_next = 1'b0;
+                    if (s_axi_bready || !s_axi_bvalid) begin
+                        s_axi_bid_next = write_id_reg;
+                        s_axi_bvalid_next = 1'b1;
+                        s_axi_awready_next = 1'b1;
+                        write_state_next = WRITE_STATE_IDLE;
+                    end else begin
+                        write_state_next = WRITE_STATE_RESP;
+                    end
+                end
+            end else begin
+                write_state_next = WRITE_STATE_BURST;
+            end
+        end
+        WRITE_STATE_RESP: begin
+            if (s_axi_bready || !s_axi_bvalid) begin
+                s_axi_bid_next = write_id_reg;
+                s_axi_bvalid_next = 1'b1;
+                s_axi_awready_next = 1'b1;
+                write_state_next = WRITE_STATE_IDLE;
+            end else begin
+                write_state_next = WRITE_STATE_RESP;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    write_state_reg <= write_state_next;
+
+    write_id_reg <= write_id_next;
+    write_addr_reg <= write_addr_next;
+    write_count_reg <= write_count_next;
+    write_size_reg <= write_size_next;
+    write_burst_reg <= write_burst_next;
+
+    s_axi_awready_reg <= s_axi_awready_next;
+    s_axi_wready_reg <= s_axi_wready_next;
+    s_axi_bid_reg <= s_axi_bid_next;
+    s_axi_bvalid_reg <= s_axi_bvalid_next;
+
+    for (i = 0; i < WORD_WIDTH; i = i + 1) begin
+        if (mem_wr_en & s_axi_wstrb[i]) begin
+            mem[write_addr_valid][WORD_SIZE*i +: WORD_SIZE] <= s_axi_wdata[WORD_SIZE*i +: WORD_SIZE];
+        end
+    end
+
+    if (rst) begin
+        write_state_reg <= WRITE_STATE_IDLE;
+
+        s_axi_awready_reg <= 1'b0;
+        s_axi_wready_reg <= 1'b0;
+        s_axi_bvalid_reg <= 1'b0;
+    end
+end
+
+always @* begin
+    read_state_next = READ_STATE_IDLE;
+
+    mem_rd_en = 1'b0;
+
+    s_axi_rid_next = s_axi_rid_reg;
+    s_axi_rlast_next = s_axi_rlast_reg;
+    s_axi_rvalid_next = s_axi_rvalid_reg && !(s_axi_rready || (`PIPELINE_OUTPUT && !s_axi_rvalid_pipe_reg));
+
+    read_id_next = read_id_reg;
+    read_addr_next = read_addr_reg;
+    read_count_next = read_count_reg;
+    read_size_next = read_size_reg;
+    read_burst_next = read_burst_reg;
+
+    s_axi_arready_next = 1'b0;
+
+    case (read_state_reg)
+        READ_STATE_IDLE: begin
+            s_axi_arready_next = 1'b1;
+
+            if (s_axi_arready && s_axi_arvalid) begin
+                read_id_next = s_axi_arid;
+                read_addr_next = s_axi_araddr;
+                read_count_next = s_axi_arlen;
+                read_size_next = s_axi_arsize < $clog2(`STRB_WIDTH) ? s_axi_arsize : $clog2(`STRB_WIDTH);
+                read_burst_next = s_axi_arburst;
+
+                s_axi_arready_next = 1'b0;
+                read_state_next = READ_STATE_BURST;
+            end else begin
+                read_state_next = READ_STATE_IDLE;
+            end
+        end
+        READ_STATE_BURST: begin
+            if (s_axi_rready || (`PIPELINE_OUTPUT && !s_axi_rvalid_pipe_reg) || !s_axi_rvalid_reg) begin
+                mem_rd_en = 1'b1;
+                s_axi_rvalid_next = 1'b1;
+                s_axi_rid_next = read_id_reg;
+                s_axi_rlast_next = read_count_reg == 0;
+                if (read_burst_reg != 2'b00) begin
+                    read_addr_next = read_addr_reg + (1 << read_size_reg);
+                end
+                read_count_next = read_count_reg - 1;
+                if (read_count_reg > 0) begin
+                    read_state_next = READ_STATE_BURST;
+                end else begin
+                    s_axi_arready_next = 1'b1;
+                    read_state_next = READ_STATE_IDLE;
+                end
+            end else begin
+                read_state_next = READ_STATE_BURST;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    read_state_reg <= read_state_next;
+
+    read_id_reg <= read_id_next;
+    read_addr_reg <= read_addr_next;
+    read_count_reg <= read_count_next;
+    read_size_reg <= read_size_next;
+    read_burst_reg <= read_burst_next;
+
+    s_axi_arready_reg <= s_axi_arready_next;
+    s_axi_rid_reg <= s_axi_rid_next;
+    s_axi_rlast_reg <= s_axi_rlast_next;
+    s_axi_rvalid_reg <= s_axi_rvalid_next;
+
+    if (mem_rd_en) begin
+        s_axi_rdata_reg <= mem[read_addr_valid];
+        $display("Here is a read command\n");
+    end
+
+    if (!s_axi_rvalid_pipe_reg || s_axi_rready) begin
+        s_axi_rid_pipe_reg <= s_axi_rid_reg;
+        s_axi_rdata_pipe_reg <= s_axi_rdata_reg;
+        s_axi_rlast_pipe_reg <= s_axi_rlast_reg;
+        s_axi_rvalid_pipe_reg <= s_axi_rvalid_reg;
+    end
+
+    if (rst) begin
+        read_state_reg <= READ_STATE_IDLE;
+
+        s_axi_arready_reg <= 1'b0;
+        s_axi_rvalid_reg <= 1'b0;
+        s_axi_rvalid_pipe_reg <= 1'b0;
+    end
+end
+
+endmodule

--- a/sysc_verilog_top.sv
+++ b/sysc_verilog_top.sv
@@ -1,0 +1,101 @@
+`timescale 1ps / 1fs
+
+`define U_DUT_TOP test_bench.axi_ram_impl_inst
+`define DATA_WIDTH 32
+`define ADDR_WIDTH 8
+`define STRB_WIDTH 4
+`define ID_WIDTH 8
+`define PIPELINE_OUTPUT 0
+/*
+* AXI4 RAM
+*/
+module sysc_verilog_top
+    (
+        input clk,
+        input                   rst,
+        input                   rst_n,
+
+        input  wire [`ID_WIDTH-1:0]    s_axi_awid,
+        input  wire [`ADDR_WIDTH-1:0]  s_axi_awaddr,
+        input  wire [7:0]             s_axi_awlen,
+        input  wire [2:0]             s_axi_awsize,
+        input  wire [1:0]             s_axi_awburst,
+        input  wire                   s_axi_awlock,
+        input  wire [3:0]             s_axi_awcache,
+        input  wire [2:0]             s_axi_awprot,
+        input  wire                   s_axi_awvalid,
+        output wire                   s_axi_awready,
+        input  wire [`DATA_WIDTH-1:0]  s_axi_wdata,
+        input  wire [`STRB_WIDTH-1:0]  s_axi_wstrb,
+        input  wire                   s_axi_wlast,
+        input  wire                   s_axi_wvalid,
+        output wire                   s_axi_wready,
+        output wire [`ID_WIDTH-1:0]    s_axi_bid,
+        output wire [1:0]             s_axi_bresp,
+        output wire                   s_axi_bvalid,
+        input  wire                   s_axi_bready,
+        input  wire [`ID_WIDTH-1:0]    s_axi_arid,
+        input  wire [`ADDR_WIDTH-1:0]  s_axi_araddr,
+        input  wire [7:0]             s_axi_arlen,
+        input  wire [2:0]             s_axi_arsize,
+        input  wire [1:0]             s_axi_arburst,
+        input  wire                   s_axi_arlock,
+        input  wire [3:0]             s_axi_arcache,
+        input  wire [2:0]             s_axi_arprot,
+        input  wire                   s_axi_arvalid,
+        output wire                   s_axi_arready,
+        output wire [`ID_WIDTH-1:0]    s_axi_rid,
+        output wire [`DATA_WIDTH-1:0]  s_axi_rdata,
+        output wire [1:0]             s_axi_rresp,
+        output wire                   s_axi_rlast,
+        output wire                   s_axi_rvalid,
+        input  wire                   s_axi_rready
+    );
+
+    //TODO: convert to svt axi interface
+
+    // Don't touch clocks, clocks are managed within soc
+    //    force axi_ram_impl.clk =     clk;
+    //    force axi_ram_impl.rst =                                       rst;
+
+    always @(*) begin
+        force `U_DUT_TOP.s_axi_awid =                                s_axi_awid;
+        force `U_DUT_TOP.s_axi_awaddr=                              s_axi_awaddr;
+        force `U_DUT_TOP.s_axi_awlen=                               s_axi_awlen;
+        force `U_DUT_TOP.s_axi_awsize=                              s_axi_awsize;
+        force `U_DUT_TOP.s_axi_awburst=                            s_axi_awburst;
+        force `U_DUT_TOP.s_axi_awlock=                              s_axi_awlock;
+        force `U_DUT_TOP.s_axi_awcache=                            s_axi_awcache;
+        force `U_DUT_TOP.s_axi_awprot=                             s_axi_awprot;
+        force `U_DUT_TOP.s_axi_awvalid=                             s_axi_awvalid;
+
+        force  s_axi_awready  = `U_DUT_TOP.s_axi_awready;
+        force  s_axi_wready   = `U_DUT_TOP.s_axi_wready;
+        force  s_axi_bid      = `U_DUT_TOP.s_axi_bid;
+        force  s_axi_bresp    = `U_DUT_TOP.s_axi_bresp;
+        force  s_axi_bvalid   = `U_DUT_TOP.s_axi_bvalid;
+        force  s_axi_arready  = `U_DUT_TOP.s_axi_arready;
+        force  s_axi_rid      = `U_DUT_TOP.s_axi_rid;
+        force  s_axi_rdata    = `U_DUT_TOP.s_axi_rdata;
+        force  s_axi_rresp    = `U_DUT_TOP.s_axi_rresp;
+        force  s_axi_rlast    = `U_DUT_TOP.s_axi_rlast;
+        force  s_axi_rvalid   = `U_DUT_TOP.s_axi_rvalid;
+
+
+        force `U_DUT_TOP.s_axi_wdata   = s_axi_wdata;
+        force `U_DUT_TOP.s_axi_wstrb   = s_axi_wstrb;
+        force `U_DUT_TOP.s_axi_wlast   = s_axi_wlast;
+        force `U_DUT_TOP.s_axi_wvalid  = s_axi_wvalid;
+        force `U_DUT_TOP.s_axi_bready  = s_axi_bready;
+        force `U_DUT_TOP.s_axi_arid    = s_axi_arid;
+        force `U_DUT_TOP.s_axi_araddr  = s_axi_araddr;
+        force `U_DUT_TOP.s_axi_arlen   = s_axi_arlen;
+        force `U_DUT_TOP.s_axi_arsize  = s_axi_arsize;
+        force `U_DUT_TOP.s_axi_arburst = s_axi_arburst;
+        force `U_DUT_TOP.s_axi_arlock  = s_axi_arlock;
+        force `U_DUT_TOP.s_axi_arcache = s_axi_arcache;
+        force `U_DUT_TOP.s_axi_arprot  = s_axi_arprot;
+        force `U_DUT_TOP.s_axi_arvalid = s_axi_arvalid;
+        force `U_DUT_TOP.s_axi_rready  = s_axi_rready;
+    end
+endmodule

--- a/test_bench.sv
+++ b/test_bench.sv
@@ -1,0 +1,92 @@
+`timescale 1ps / 1fs
+module test_bench();
+    logic clk;
+    logic rst;
+`define DATA_WIDTH 32
+`define ADDR_WIDTH 8
+`define STRB_WIDTH 4
+`define ID_WIDTH 8
+`define PIPELINE_OUTPUT 0
+  /*AUTOWIRE*/
+  // Beginning of automatic wires (for undeclared instantiated-module outputs)
+  wire                  s_axi_arready;          // From axi_ram_impl_inst of axi_ram_impl.v
+  wire                  s_axi_awready;          // From axi_ram_impl_inst of axi_ram_impl.v
+  wire [`ID_WIDTH-1:0]  s_axi_bid;              // From axi_ram_impl_inst of axi_ram_impl.v
+  wire [1:0]            s_axi_bresp;            // From axi_ram_impl_inst of axi_ram_impl.v
+  wire                  s_axi_bvalid;           // From axi_ram_impl_inst of axi_ram_impl.v
+  wire [`DATA_WIDTH-1:0] s_axi_rdata;           // From axi_ram_impl_inst of axi_ram_impl.v
+  wire [`ID_WIDTH-1:0]  s_axi_rid;              // From axi_ram_impl_inst of axi_ram_impl.v
+  wire                  s_axi_rlast;            // From axi_ram_impl_inst of axi_ram_impl.v
+  wire [1:0]            s_axi_rresp;            // From axi_ram_impl_inst of axi_ram_impl.v
+  wire                  s_axi_rvalid;           // From axi_ram_impl_inst of axi_ram_impl.v
+  wire                  s_axi_wready;           // From axi_ram_impl_inst of axi_ram_impl.v
+  // End of automatics
+  /*AUTOREG*/
+
+    initial begin
+        clk = 1'b0;
+        forever begin
+            #500 clk = ~clk;
+        end
+    end
+
+    initial begin
+        rst = 1'b1;
+        #100000 rst = 1'b0;
+    end
+
+    axi_ram_impl axi_ram_impl_inst(/*AUTOINST*/
+                                   // Outputs
+                                   .s_axi_awready       (s_axi_awready),
+                                   .s_axi_wready        (s_axi_wready),
+                                   .s_axi_bid           (s_axi_bid),
+                                   .s_axi_bresp         (s_axi_bresp),
+                                   .s_axi_bvalid        (s_axi_bvalid),
+                                   .s_axi_arready       (s_axi_arready),
+                                   .s_axi_rid           (s_axi_rid),
+                                   .s_axi_rdata         (s_axi_rdata),
+                                   .s_axi_rresp         (s_axi_rresp),
+                                   .s_axi_rlast         (s_axi_rlast),
+                                   .s_axi_rvalid        (s_axi_rvalid),
+                                   // Inputs
+                                   .clk                 (clk),
+                                   .rst                 (rst),
+                                   .s_axi_awid          (s_axi_awid),
+                                   .s_axi_awaddr        (s_axi_awaddr),
+                                   .s_axi_awlen         (s_axi_awlen),
+                                   .s_axi_awsize        (s_axi_awsize),
+                                   .s_axi_awburst       (s_axi_awburst),
+                                   .s_axi_awlock        (s_axi_awlock),
+                                   .s_axi_awcache       (s_axi_awcache),
+                                   .s_axi_awprot        (s_axi_awprot),
+                                   .s_axi_awvalid       (s_axi_awvalid),
+                                   .s_axi_wdata         (s_axi_wdata),
+                                   .s_axi_wstrb         (s_axi_wstrb),
+                                   .s_axi_wlast         (s_axi_wlast),
+                                   .s_axi_wvalid        (s_axi_wvalid),
+                                   .s_axi_bready        (s_axi_bready),
+                                   .s_axi_arid          (s_axi_arid),
+                                   .s_axi_araddr        (s_axi_araddr),
+                                   .s_axi_arlen         (s_axi_arlen),
+                                   .s_axi_arsize        (s_axi_arsize),
+                                   .s_axi_arburst       (s_axi_arburst),
+                                   .s_axi_arlock        (s_axi_arlock),
+                                   .s_axi_arcache       (s_axi_arcache),
+                                   .s_axi_arprot        (s_axi_arprot),
+                                   .s_axi_arvalid       (s_axi_arvalid),
+                                   .s_axi_rready        (s_axi_rready)
+    );
+
+
+    initial begin                                                                                                                                                                               
+        $fsdbDumpfile("tb_cohort.fsdb",50);                                                                                                                                                     
+        $fsdbDumpvars(0, test_bench,"+all");                                                                                                                                                     
+        $fsdbDumpvars(0, sc_main,"+all");                                                                                                                                                     
+    end
+
+endmodule
+
+
+// Local Variables:
+// verilog-library-files: ("axi_ram_impl.sv")
+// End:

--- a/zynqmp_demo.cc
+++ b/zynqmp_demo.cc
@@ -595,6 +595,7 @@ void usage(void)
 
 int sc_main(int argc, char* argv[])
 {
+    const char* socket_name;    
 	Top *top;
 	uint64_t sync_quantum;
 	sc_trace_file *trace_fp = NULL;
@@ -605,25 +606,27 @@ int sc_main(int argc, char* argv[])
 
 	if (argc < 3) {
 		sync_quantum = 10000;
+        socket_name = "unix:/tmp/qemu/qemu-rport-_machine_cosim";
 	} else {
 		sync_quantum = strtoull(argv[2], NULL, 10);
+        socket_name = argv[1];
 	}
 
-	sc_set_time_resolution(1, SC_PS);
+	sc_set_time_resolution(1, SC_FS);
 
-	top = new Top("top", argv[1], sc_time((double) sync_quantum, SC_NS));
+	top = new Top("top", socket_name, sc_time((double) sync_quantum, SC_NS));
 
-	if (argc < 3) {
-		sc_start(1, SC_PS);
-		sc_stop();
-		usage();
-		exit(EXIT_FAILURE);
-	}
+//	if (argc < 3) {
+//		sc_start(1, SC_PS);
+//		sc_stop();
+//		usage();
+//		exit(EXIT_FAILURE);
+//	}
 
 	trace_fp = sc_create_vcd_trace_file("trace");
 	trace(trace_fp, *top, top->name());
 
-	sc_start();
+	sc_start(10000000, SC_SEC);
 	if (trace_fp) {
 		sc_close_vcd_trace_file(trace_fp);
 	}

--- a/zynqmp_vcs_demo.cc
+++ b/zynqmp_vcs_demo.cc
@@ -40,7 +40,7 @@ using namespace sc_dt;
 using namespace std;
 #define HAVE_VERILOG
 #define HAVE_VERILOG_VCS
-#include "axi_ram.h"
+#include "sysc_verilog_top.h"
 #include "iconnect.h"
 #include "debugdev.h"
 #include "demo-dma.h"
@@ -73,7 +73,7 @@ SC_MODULE(Top)
 	
 	tlm2axi_bridge<ADDR_WIDTH, DATA_WIDTH> *tlm2axi_bridge_inst;
 	
-	axi_ram *axi_ram_inst;
+	sysc_verilog_top *sysc_verilog_top_inst;
 
 
     sc_signal<sc_bv<ID_WIDTH> >     s_axi_awid;
@@ -184,7 +184,7 @@ SC_MODULE(Top)
 		bus->memmap(BASE_ADDR + 0x10000ULL, 0x10 - 1,
 				ADDRMODE_RELATIVE, -1, dma->tgt_socket);
 
-		tlm2axi_bridge_inst = new tlm2axi_bridge<ADDR_WIDTH, DATA_WIDTH> ("tlm2axi-bridge-inst");
+		tlm2axi_bridge_inst = new tlm2axi_bridge<ADDR_WIDTH, DATA_WIDTH> ("tlm2axi_bridge_inst");
 		
 		bus->memmap(BASE_ADDR + 0x20000ULL, 0x10 - 1,
 				ADDRMODE_RELATIVE, -1, tlm2axi_bridge_inst->tgt_socket);
@@ -198,49 +198,49 @@ SC_MODULE(Top)
 
 		debug->irq(zynq.pl2ps_irq[0]);
 		dma->irq(zynq.pl2ps_irq[1]);
-
 		/* Slow clock to keep simulation fast.  */
-		clk = new sc_clock("clk", sc_time(10, SC_US));
+		clk = new sc_clock("clk", sc_time(1, SC_NS));
 		
-		axi_ram_inst = new axi_ram("axi_ram_inst");
-        axi_ram_inst->clk(*clk);
-        axi_ram_inst->rst(rst);
+		sysc_verilog_top_inst = new sysc_verilog_top("sysc_verilog_top_inst");
+        sysc_verilog_top_inst->clk(*clk);
+        sysc_verilog_top_inst->rst(rst);
+        sysc_verilog_top_inst->rst_n(rst_n);
         
-        axi_ram_inst->s_axi_awid(s_axi_awid);
-        axi_ram_inst->s_axi_awaddr(s_axi_awaddr);
-        axi_ram_inst->s_axi_awlen(s_axi_awlen);
-        axi_ram_inst->s_axi_awsize(s_axi_awsize);
-        axi_ram_inst->s_axi_awburst(s_axi_awburst);
-        axi_ram_inst->s_axi_awlock(s_axi_awlock);
-        axi_ram_inst->s_axi_awcache(s_axi_awcache);
-        axi_ram_inst->s_axi_awprot(s_axi_awprot);
-        axi_ram_inst->s_axi_awvalid(s_axi_awvalid);
-        axi_ram_inst->s_axi_awready(s_axi_awready);
-        axi_ram_inst->s_axi_wdata(s_axi_wdata);
-        axi_ram_inst->s_axi_wstrb(s_axi_wstrb);
-        axi_ram_inst->s_axi_wlast(s_axi_wlast);
-        axi_ram_inst->s_axi_wvalid(s_axi_wvalid);
-        axi_ram_inst->s_axi_wready(s_axi_wready);
-        axi_ram_inst->s_axi_bid(s_axi_bid);
-        axi_ram_inst->s_axi_bresp(s_axi_bresp);
-        axi_ram_inst->s_axi_bvalid(s_axi_bvalid);
-        axi_ram_inst->s_axi_bready(s_axi_bready);
-        axi_ram_inst->s_axi_arid(s_axi_arid);
-        axi_ram_inst->s_axi_araddr(s_axi_araddr);
-        axi_ram_inst->s_axi_arlen(s_axi_arlen);
-        axi_ram_inst->s_axi_arsize(s_axi_arsize);
-        axi_ram_inst->s_axi_arburst(s_axi_arburst);
-        axi_ram_inst->s_axi_arlock(s_axi_arlock);
-        axi_ram_inst->s_axi_arcache(s_axi_arcache);
-        axi_ram_inst->s_axi_arprot(s_axi_arprot);
-        axi_ram_inst->s_axi_arvalid(s_axi_arvalid);
-        axi_ram_inst->s_axi_arready(s_axi_arready);
-        axi_ram_inst->s_axi_rid(s_axi_rid);
-        axi_ram_inst->s_axi_rdata(s_axi_rdata);
-        axi_ram_inst->s_axi_rresp(s_axi_rresp);
-        axi_ram_inst->s_axi_rlast(s_axi_rlast);
-        axi_ram_inst->s_axi_rvalid(s_axi_rvalid);
-        axi_ram_inst->s_axi_rready(s_axi_rready);
+        sysc_verilog_top_inst->s_axi_awid(s_axi_awid);
+        sysc_verilog_top_inst->s_axi_awaddr(s_axi_awaddr);
+        sysc_verilog_top_inst->s_axi_awlen(s_axi_awlen);
+        sysc_verilog_top_inst->s_axi_awsize(s_axi_awsize);
+        sysc_verilog_top_inst->s_axi_awburst(s_axi_awburst);
+        sysc_verilog_top_inst->s_axi_awlock(s_axi_awlock);
+        sysc_verilog_top_inst->s_axi_awcache(s_axi_awcache);
+        sysc_verilog_top_inst->s_axi_awprot(s_axi_awprot);
+        sysc_verilog_top_inst->s_axi_awvalid(s_axi_awvalid);
+        sysc_verilog_top_inst->s_axi_awready(s_axi_awready);
+        sysc_verilog_top_inst->s_axi_wdata(s_axi_wdata);
+        sysc_verilog_top_inst->s_axi_wstrb(s_axi_wstrb);
+        sysc_verilog_top_inst->s_axi_wlast(s_axi_wlast);
+        sysc_verilog_top_inst->s_axi_wvalid(s_axi_wvalid);
+        sysc_verilog_top_inst->s_axi_wready(s_axi_wready);
+        sysc_verilog_top_inst->s_axi_bid(s_axi_bid);
+        sysc_verilog_top_inst->s_axi_bresp(s_axi_bresp);
+        sysc_verilog_top_inst->s_axi_bvalid(s_axi_bvalid);
+        sysc_verilog_top_inst->s_axi_bready(s_axi_bready);
+        sysc_verilog_top_inst->s_axi_arid(s_axi_arid);
+        sysc_verilog_top_inst->s_axi_araddr(s_axi_araddr);
+        sysc_verilog_top_inst->s_axi_arlen(s_axi_arlen);
+        sysc_verilog_top_inst->s_axi_arsize(s_axi_arsize);
+        sysc_verilog_top_inst->s_axi_arburst(s_axi_arburst);
+        sysc_verilog_top_inst->s_axi_arlock(s_axi_arlock);
+        sysc_verilog_top_inst->s_axi_arcache(s_axi_arcache);
+        sysc_verilog_top_inst->s_axi_arprot(s_axi_arprot);
+        sysc_verilog_top_inst->s_axi_arvalid(s_axi_arvalid);
+        sysc_verilog_top_inst->s_axi_arready(s_axi_arready);
+        sysc_verilog_top_inst->s_axi_rid(s_axi_rid);
+        sysc_verilog_top_inst->s_axi_rdata(s_axi_rdata);
+        sysc_verilog_top_inst->s_axi_rresp(s_axi_rresp);
+        sysc_verilog_top_inst->s_axi_rlast(s_axi_rlast);
+        sysc_verilog_top_inst->s_axi_rvalid(s_axi_rvalid);
+        sysc_verilog_top_inst->s_axi_rready(s_axi_rready);
 
         tlm2axi_bridge_inst->clk(*clk);
 	tlm2axi_bridge_inst->resetn(rst_n);

--- a/zynqmp_vcs_demo.cc
+++ b/zynqmp_vcs_demo.cc
@@ -1,0 +1,346 @@
+/*
+ * Top level of the ZynqMP cosim example.
+ *
+ * Copyright (c) 2014 Xilinx Inc.
+ * Written by Edgar E. Iglesias
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#define SC_INCLUDE_DYNAMIC_PROCESSES
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include "systemc.h"
+#include "tlm_utils/simple_initiator_socket.h"
+#include "tlm_utils/simple_target_socket.h"
+#include "tlm_utils/tlm_quantumkeeper.h"
+
+using namespace sc_core;
+using namespace sc_dt;
+using namespace std;
+#define HAVE_VERILOG
+#define HAVE_VERILOG_VCS
+#include "axi_ram.h"
+#include "iconnect.h"
+#include "debugdev.h"
+#include "demo-dma.h"
+#include "xilinx-zynqmp.h"
+
+#include "tlm-bridges/tlm2axi-bridge.h"
+
+#define NR_MASTERS	2
+#define NR_DEVICES	4
+
+#ifndef BASE_ADDR
+#define BASE_ADDR 0x28000000ULL
+#endif
+
+#define ID_WIDTH 8
+#define ADDR_WIDTH 8
+#define DATA_WIDTH 32
+#define STRB_WIDTH 4
+SC_MODULE(Top)
+{
+	SC_HAS_PROCESS(Top);
+	iconnect<NR_MASTERS, NR_DEVICES>	*bus;
+	xilinx_zynqmp zynq;
+	debugdev *debug;
+	demodma *dma;
+
+	sc_signal<bool> rst, rst_n;
+
+	sc_clock *clk;
+	
+	tlm2axi_bridge<ADDR_WIDTH, DATA_WIDTH> *tlm2axi_bridge_inst;
+	
+	axi_ram *axi_ram_inst;
+
+
+    sc_signal<sc_bv<ID_WIDTH> >     s_axi_awid;
+    sc_signal<sc_bv<ADDR_WIDTH> >   s_axi_awaddr;
+    sc_signal<sc_bv<8> >            s_axi_awlen;
+    sc_signal<sc_bv<3> >            s_axi_awsize;
+    sc_signal<sc_bv<2> >            s_axi_awburst;
+    sc_signal<bool>                s_axi_awlock;
+    sc_signal<sc_bv<4> >            s_axi_awcache;
+    sc_signal<sc_bv<3> >            s_axi_awprot;
+    sc_signal<bool>                s_axi_awvalid;
+    sc_signal<bool>                s_axi_awready;
+    sc_signal<sc_bv<DATA_WIDTH> >   s_axi_wdata;
+    sc_signal<sc_bv<STRB_WIDTH> >   s_axi_wstrb;
+    sc_signal<bool>                s_axi_wlast;
+    sc_signal<bool>                s_axi_wvalid;
+    sc_signal<bool>                s_axi_wready;
+    sc_signal<sc_bv<ID_WIDTH> >     s_axi_bid;
+    sc_signal<sc_bv<2> >            s_axi_bresp;
+    sc_signal<bool>                s_axi_bvalid;
+    sc_signal<bool>                s_axi_bready;
+    sc_signal<sc_bv<ID_WIDTH> >     s_axi_arid;
+    sc_signal<sc_bv<ADDR_WIDTH> >   s_axi_araddr;
+    sc_signal<sc_bv<8> >            s_axi_arlen;
+    sc_signal<sc_bv<3> >            s_axi_arsize;
+    sc_signal<sc_bv<2> >            s_axi_arburst;
+    sc_signal<bool>                s_axi_arlock;
+    sc_signal<sc_bv<4> >            s_axi_arcache;
+    sc_signal<sc_bv<3> >            s_axi_arprot;
+    sc_signal<bool>                s_axi_arvalid;
+    sc_signal<bool>                s_axi_arready;
+    sc_signal<sc_bv<ID_WIDTH> >     s_axi_rid;
+    sc_signal<sc_bv<DATA_WIDTH> >   s_axi_rdata;
+    sc_signal<sc_bv<2> >            s_axi_rresp;
+    sc_signal<bool>                s_axi_rlast;
+    sc_signal<bool>                s_axi_rvalid;
+    sc_signal<bool>                s_axi_rready;
+    sc_signal<sc_bv<2> >            s_axi_ruser;
+    sc_signal<sc_bv<2> >            s_axi_awuser;
+    sc_signal<sc_bv<2> >            s_axi_wuser;
+    sc_signal<sc_bv<2> >            s_axi_aruser;
+    sc_signal<sc_bv<2> >            s_axi_buser;
+    sc_signal<sc_bv<4> >            s_axi_arqos;
+    sc_signal<sc_bv<4> >            s_axi_awqos;
+    sc_signal<sc_bv<4> >            s_axi_arregion;
+    sc_signal<sc_bv<4> >            s_axi_awregion;
+
+	Top(sc_module_name name, const char *sk_descr, sc_time quantum) :
+		zynq("zynq", sk_descr),
+		rst("rst"),
+		rst_n("rst_n"),
+		
+        s_axi_awid("cosim_s_axi_awid"),
+        s_axi_awaddr("cosim_s_axi_awaddr"),
+        s_axi_awlen("cosim_s_axi_awlen"),
+        s_axi_awsize("cosim_s_axi_awsize"),
+        s_axi_awburst("cosim_s_axi_awburst"),
+        s_axi_awlock("cosim_s_axi_awlock"),
+        s_axi_awcache("cosim_s_axi_awcache"),
+        s_axi_awprot("cosim_s_axi_awprot"),
+        s_axi_awvalid("cosim_s_axi_awvalid"),
+        s_axi_awready("cosim_s_axi_awready"),
+        s_axi_wdata("cosim_s_axi_wdata"),
+        s_axi_wstrb("cosim_s_axi_wstrb"),
+        s_axi_wlast("cosim_s_axi_wlast"),
+        s_axi_wvalid("cosim_s_axi_wvalid"),
+        s_axi_wready("cosim_s_axi_wready"),
+        s_axi_bid("cosim_s_axi_bid"),
+        s_axi_bresp("cosim_s_axi_bresp"),
+        s_axi_bvalid("cosim_s_axi_bvalid"),
+        s_axi_bready("cosim_s_axi_bready"),
+        s_axi_arid("cosim_s_axi_arid"),
+        s_axi_araddr("cosim_s_axi_araddr"),
+        s_axi_arlen("cosim_s_axi_arlen"),
+        s_axi_arsize("cosim_s_axi_arsize"),
+        s_axi_arburst("cosim_s_axi_arburst"),
+        s_axi_arlock("cosim_s_axi_arlock"),
+        s_axi_arcache("cosim_s_axi_arcache"),
+        s_axi_arprot("cosim_s_axi_arprot"),
+        s_axi_arvalid("cosim_s_axi_arvalid"),
+        s_axi_arready("cosim_s_axi_arready"),
+        s_axi_rid("cosim_s_axi_rid"),
+        s_axi_rdata("cosim_s_axi_rdata"),
+        s_axi_rresp("cosim_s_axi_rresp"),
+        s_axi_rlast("cosim_s_axi_rlast"),
+        s_axi_rvalid("cosim_s_axi_rvalid"),
+        s_axi_rready("cosim_s_axi_rready"),
+	s_axi_ruser("cosim_s_axi_ruser"),
+	s_axi_awuser("cosim_s_axi_awuser"),
+	s_axi_wuser("cosim_s_axi_wuser"),
+	s_axi_aruser("cosim_s_axi_aruser"),
+	s_axi_buser("cosim_s_axi_buser"),
+	s_axi_awqos("cosim_s_axi_awqos"),
+	s_axi_arqos("cosim_s_axi_arqos"),
+	s_axi_arregion("cosim_s_axi_arregion"),
+	s_axi_awregion("cosim_s_axi_awregion")
+	{
+        printf("initializing top design\n");
+		m_qk.set_global_quantum(quantum);
+
+		zynq.rst(rst);
+		bus   = new iconnect<NR_MASTERS, NR_DEVICES> ("bus");
+		debug = new debugdev("debug");
+		dma = new demodma("demodma");
+
+		bus->memmap(BASE_ADDR, 0x100 - 1,
+				ADDRMODE_RELATIVE, -1, debug->socket);
+		bus->memmap(BASE_ADDR + 0x10000ULL, 0x10 - 1,
+				ADDRMODE_RELATIVE, -1, dma->tgt_socket);
+
+		tlm2axi_bridge_inst = new tlm2axi_bridge<ADDR_WIDTH, DATA_WIDTH> ("tlm2axi-bridge-inst");
+		
+		bus->memmap(BASE_ADDR + 0x20000ULL, 0x10 - 1,
+				ADDRMODE_RELATIVE, -1, tlm2axi_bridge_inst->tgt_socket);
+
+		bus->memmap(0x0LL, 0xffffffff - 1,
+				ADDRMODE_RELATIVE, -1, *(zynq.s_axi_hpc_fpd[0]));
+
+		zynq.s_axi_hpm_fpd[0]->bind(*(bus->t_sk[0]));
+
+		dma->init_socket.bind(*(bus->t_sk[1]));
+
+		debug->irq(zynq.pl2ps_irq[0]);
+		dma->irq(zynq.pl2ps_irq[1]);
+
+		/* Slow clock to keep simulation fast.  */
+		clk = new sc_clock("clk", sc_time(10, SC_US));
+		
+		axi_ram_inst = new axi_ram("axi_ram_inst");
+        axi_ram_inst->clk(*clk);
+        axi_ram_inst->rst(rst);
+        
+        axi_ram_inst->s_axi_awid(s_axi_awid);
+        axi_ram_inst->s_axi_awaddr(s_axi_awaddr);
+        axi_ram_inst->s_axi_awlen(s_axi_awlen);
+        axi_ram_inst->s_axi_awsize(s_axi_awsize);
+        axi_ram_inst->s_axi_awburst(s_axi_awburst);
+        axi_ram_inst->s_axi_awlock(s_axi_awlock);
+        axi_ram_inst->s_axi_awcache(s_axi_awcache);
+        axi_ram_inst->s_axi_awprot(s_axi_awprot);
+        axi_ram_inst->s_axi_awvalid(s_axi_awvalid);
+        axi_ram_inst->s_axi_awready(s_axi_awready);
+        axi_ram_inst->s_axi_wdata(s_axi_wdata);
+        axi_ram_inst->s_axi_wstrb(s_axi_wstrb);
+        axi_ram_inst->s_axi_wlast(s_axi_wlast);
+        axi_ram_inst->s_axi_wvalid(s_axi_wvalid);
+        axi_ram_inst->s_axi_wready(s_axi_wready);
+        axi_ram_inst->s_axi_bid(s_axi_bid);
+        axi_ram_inst->s_axi_bresp(s_axi_bresp);
+        axi_ram_inst->s_axi_bvalid(s_axi_bvalid);
+        axi_ram_inst->s_axi_bready(s_axi_bready);
+        axi_ram_inst->s_axi_arid(s_axi_arid);
+        axi_ram_inst->s_axi_araddr(s_axi_araddr);
+        axi_ram_inst->s_axi_arlen(s_axi_arlen);
+        axi_ram_inst->s_axi_arsize(s_axi_arsize);
+        axi_ram_inst->s_axi_arburst(s_axi_arburst);
+        axi_ram_inst->s_axi_arlock(s_axi_arlock);
+        axi_ram_inst->s_axi_arcache(s_axi_arcache);
+        axi_ram_inst->s_axi_arprot(s_axi_arprot);
+        axi_ram_inst->s_axi_arvalid(s_axi_arvalid);
+        axi_ram_inst->s_axi_arready(s_axi_arready);
+        axi_ram_inst->s_axi_rid(s_axi_rid);
+        axi_ram_inst->s_axi_rdata(s_axi_rdata);
+        axi_ram_inst->s_axi_rresp(s_axi_rresp);
+        axi_ram_inst->s_axi_rlast(s_axi_rlast);
+        axi_ram_inst->s_axi_rvalid(s_axi_rvalid);
+        axi_ram_inst->s_axi_rready(s_axi_rready);
+
+        tlm2axi_bridge_inst->clk(*clk);
+	tlm2axi_bridge_inst->resetn(rst_n);
+
+        tlm2axi_bridge_inst->awid(s_axi_awid);
+        tlm2axi_bridge_inst->awaddr(s_axi_awaddr);
+        tlm2axi_bridge_inst->awlen(s_axi_awlen);
+        tlm2axi_bridge_inst->awsize(s_axi_awsize);
+        tlm2axi_bridge_inst->awburst(s_axi_awburst);
+        tlm2axi_bridge_inst->awlock(s_axi_awlock);
+        tlm2axi_bridge_inst->awcache(s_axi_awcache);
+        tlm2axi_bridge_inst->awprot(s_axi_awprot);
+        tlm2axi_bridge_inst->awvalid(s_axi_awvalid);
+        tlm2axi_bridge_inst->awready(s_axi_awready);
+        tlm2axi_bridge_inst->wdata(s_axi_wdata);
+        tlm2axi_bridge_inst->wstrb(s_axi_wstrb);
+        tlm2axi_bridge_inst->wlast(s_axi_wlast);
+        tlm2axi_bridge_inst->wvalid(s_axi_wvalid);
+        tlm2axi_bridge_inst->wready(s_axi_wready);
+        tlm2axi_bridge_inst->bid(s_axi_bid);
+        tlm2axi_bridge_inst->bresp(s_axi_bresp);
+        tlm2axi_bridge_inst->bvalid(s_axi_bvalid);
+        tlm2axi_bridge_inst->bready(s_axi_bready);
+        tlm2axi_bridge_inst->arid(s_axi_arid);
+        tlm2axi_bridge_inst->araddr(s_axi_araddr);
+        tlm2axi_bridge_inst->arlen(s_axi_arlen);
+        tlm2axi_bridge_inst->arsize(s_axi_arsize);
+        tlm2axi_bridge_inst->arburst(s_axi_arburst);
+        tlm2axi_bridge_inst->arlock(s_axi_arlock);
+        tlm2axi_bridge_inst->arcache(s_axi_arcache);
+        tlm2axi_bridge_inst->arprot(s_axi_arprot);
+        tlm2axi_bridge_inst->arvalid(s_axi_arvalid);
+        tlm2axi_bridge_inst->arready(s_axi_arready);
+        tlm2axi_bridge_inst->rid(s_axi_rid);
+        tlm2axi_bridge_inst->rdata(s_axi_rdata);
+        tlm2axi_bridge_inst->rresp(s_axi_rresp);
+        tlm2axi_bridge_inst->rlast(s_axi_rlast);
+        tlm2axi_bridge_inst->rvalid(s_axi_rvalid);
+        tlm2axi_bridge_inst->rready(s_axi_rready);
+        tlm2axi_bridge_inst->ruser(s_axi_ruser);
+        tlm2axi_bridge_inst->aruser(s_axi_aruser);
+        tlm2axi_bridge_inst->awuser(s_axi_awuser);
+        tlm2axi_bridge_inst->wuser(s_axi_wuser);
+        tlm2axi_bridge_inst->buser(s_axi_buser);
+        tlm2axi_bridge_inst->arqos(s_axi_arqos);
+        tlm2axi_bridge_inst->awqos(s_axi_awqos);
+        tlm2axi_bridge_inst->awregion(s_axi_awregion);
+        tlm2axi_bridge_inst->arregion(s_axi_arregion);
+	
+	s_axi_ruser = 0;
+	s_axi_aruser = 0;
+	s_axi_awuser = 0;
+	s_axi_wuser = 0;
+	s_axi_buser = 0;
+	s_axi_arqos = 0;
+	s_axi_awqos = 0;
+
+
+
+		zynq.tie_off();
+	}
+
+private:
+	tlm_utils::tlm_quantumkeeper m_qk;
+};
+
+void usage(void)
+{
+	cout << "tlm socket-path sync-quantum-ns" << endl;
+}
+
+int sc_main(int argc, char* argv[])
+{
+	Top *top;
+    const char *socket_name;
+	uint64_t sync_quantum;
+
+//	if (argc < 3) {
+		sync_quantum = 100000;
+        	socket_name = "unix:/tmp/qemu/qemu-rport-_machine_cosim";
+//	} else {
+//		sync_quantum = strtoull(argv[2], NULL, 10);
+ //       	socket_name = argv[1];
+//	}
+
+	sc_set_time_resolution(1, SC_FS);
+
+	top = new Top("top", socket_name, sc_time((double) sync_quantum, SC_PS));
+
+    printf("realy to pull the reset signal\n");
+	/* Pull the reset signal.  */
+	top->rst.write(true);
+	top->rst_n.write(false);
+    printf("start sc_start for reset\n");
+	sc_start(1, SC_US);
+	top->rst.write(false);
+	top->rst_n.write(true);
+
+    printf("formal starting the design\n");
+	sc_start(10000000, SC_SEC);
+    sc_stop();
+	return -8;
+}


### PR DESCRIPTION
This PR adds vcs support to systemc cosim demo.
Note that this requires VCS version > 2018, and systemc 2.3.2 is required.
This also adds an implicit socket path to deal with some problems with VCS elaboration, and change SC_START to a large value because vcs default run time length is very small.